### PR TITLE
Update: Add Retryer mechanism to existing auto scaling group operations (refs #215)

### DIFF
--- a/shredder-core/src/main/java/com/adobe/aam/shredder/core/aws/servergroup/AwsAutoScaleGroupHelper.java
+++ b/shredder-core/src/main/java/com/adobe/aam/shredder/core/aws/servergroup/AwsAutoScaleGroupHelper.java
@@ -13,18 +13,55 @@
 package com.adobe.aam.shredder.core.aws.servergroup;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.model.*;
+import com.github.rholder.retry.Attempt;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryListener;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class AwsAutoScaleGroupHelper implements AutoScaleGroupHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(AwsAutoScaleGroupHelper.class);
+
+    private final Retryer<DescribeAutoScalingInstancesResult> describeAutoScalingInstancesRetryer = RetryerBuilder.<DescribeAutoScalingInstancesResult>newBuilder()
+            .retryIfException(this::shouldRetryOnException)
+            .withWaitStrategy(WaitStrategies.randomWait(2, TimeUnit.MINUTES))
+            .withStopStrategy(StopStrategies.stopAfterAttempt(7))
+            .withRetryListener(new RetryListener() {
+                @Override
+                public <V> void onRetry(Attempt<V> attempt) {
+                    if (attempt.hasException()) {
+                        LOG.warn("Failed to send lifecycle event to AWS. {}", attempt.getExceptionCause().getMessage());
+                    }
+                }
+            })
+            .build();
+
+    private final Retryer<DescribeLifecycleHooksResult> describeLifecycleHooksRetryer = RetryerBuilder.<DescribeLifecycleHooksResult>newBuilder()
+            .retryIfException(this::shouldRetryOnException)
+            .withWaitStrategy(WaitStrategies.randomWait(2, TimeUnit.MINUTES))
+            .withStopStrategy(StopStrategies.stopAfterAttempt(7))
+            .withRetryListener(new RetryListener() {
+                @Override
+                public <V> void onRetry(Attempt<V> attempt) {
+                    if (attempt.hasException()) {
+                        LOG.warn("Failed to send lifecycle event to AWS. {}", attempt.getExceptionCause().getMessage());
+                    }
+                }
+            })
+            .build();
 
     private AmazonAutoScaling asg;
 
@@ -37,7 +74,7 @@ public class AwsAutoScaleGroupHelper implements AutoScaleGroupHelper {
     public Optional<AutoScalingInstanceDetails> getCurrentAutoScalingGroup(String instanceId) {
         try {
             DescribeAutoScalingInstancesRequest request = new DescribeAutoScalingInstancesRequest().withInstanceIds(instanceId);
-            DescribeAutoScalingInstancesResult describeResult = asg.describeAutoScalingInstances(request);
+            DescribeAutoScalingInstancesResult describeResult = describeAutoScalingInstancesRetryer.call(getCurrentAutoScalingGroupCommand(request));
 
             List<AutoScalingInstanceDetails> asgs = describeResult.getAutoScalingInstances();
             if (asgs.isEmpty()) {
@@ -45,10 +82,14 @@ public class AwsAutoScaleGroupHelper implements AutoScaleGroupHelper {
             }
 
             return Optional.ofNullable(asgs.iterator().next());
-        } catch (AmazonClientException e) {
+        } catch (AmazonClientException | ExecutionException | RetryException e) {
             LOG.error("Unable to fetch current AutoScaleGroup for instance: {} {}", instanceId, e);
             return Optional.empty();
         }
+    }
+
+    private Callable<DescribeAutoScalingInstancesResult> getCurrentAutoScalingGroupCommand(DescribeAutoScalingInstancesRequest request) {
+        return () -> asg.describeAutoScalingInstances(request);
     }
 
     @Override
@@ -56,7 +97,7 @@ public class AwsAutoScaleGroupHelper implements AutoScaleGroupHelper {
         try {
             DescribeLifecycleHooksRequest request = new DescribeLifecycleHooksRequest()
                     .withAutoScalingGroupName(autoScaleGroupName);
-            DescribeLifecycleHooksResult hooks = asg.describeLifecycleHooks(request);
+            DescribeLifecycleHooksResult hooks = describeLifecycleHooksRetryer.call(getLifecycleHookNameCommand(request));
             for (LifecycleHook hook : hooks.getLifecycleHooks()) {
                 if (transitionType.equals(hook.getLifecycleTransition())) {
                     return Optional.ofNullable(hook.getLifecycleHookName());
@@ -64,10 +105,14 @@ public class AwsAutoScaleGroupHelper implements AutoScaleGroupHelper {
             }
 
             return Optional.empty();
-        }  catch (AmazonClientException e) {
+        }  catch (AmazonClientException | ExecutionException | RetryException e) {
             LOG.error("Unable to fetch current Lifecycle Hook {}", transitionType, e);
             return Optional.empty();
         }
+    }
+
+    private Callable<DescribeLifecycleHooksResult> getLifecycleHookNameCommand(DescribeLifecycleHooksRequest request) {
+        return () -> asg.describeLifecycleHooks(request);
     }
 
     @Override
@@ -78,5 +123,11 @@ public class AwsAutoScaleGroupHelper implements AutoScaleGroupHelper {
     @Override
     public void completeLifecycleAction(CompleteLifecycleActionRequest request) {
         asg.completeLifecycleAction(request);
+    }
+
+    private boolean shouldRetryOnException(Throwable throwable) {
+        return throwable != null
+                && throwable.getMessage() != null
+                && throwable.getMessage().contains("Rate exceeded");
     }
 }


### PR DESCRIPTION
### A word of appreciation

We thank you for your support.

### What does this PR do?

Indicate what the changes in this PR accomplish -- whether to fix a bug, introduce a new feature, clean up documentation, etc.

Adding retryer mechanism for EC2 Auto Scale Group interactions to address Rate Limit

### Checklist

- [x] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] An issue has been created for this PR
- [x] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [x] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [x] Unit tests all pass (`./gradlew test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
